### PR TITLE
❄️ Create flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
               doCheck = false;
               src = self;
 
-              postInstall = ''
+              postInstall = pkgs.lib.optional stdenv.isLinux ''
                 wrapProgram $out/bin/domain-check --prefix PATH : ${
                   pkgs.lib.makeBinPath [ pkgs.dnsutils ]
                 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description =
+    "A script running over all TLDs that fulfill specified requirements |check if `name.TLD` is still free.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+
+      in
+      rec {
+
+        formatter = pkgs.nixpkgs-fmt;
+
+        packages = flake-utils.lib.flattenTree rec {
+
+          domain-check = with pkgs.python39Packages;
+            pkgs.python39Packages.buildPythonPackage rec {
+              pname = "domain-check";
+              version = "1.0.1";
+
+              propagatedBuildInputs = [ requests ];
+              buildInputs = [ pkgs.makeWrapper ];
+              doCheck = false;
+              src = self;
+
+              postInstall = ''
+                wrapProgram $out/bin/domain-check --prefix PATH : ${
+                  pkgs.lib.makeBinPath [ pkgs.dnsutils ]
+                }
+              '';
+
+              meta = with pkgs.lib; {
+                description =
+                  "A script running over all TLDs that fulfill specified requirements.";
+                homepage = "https://github.com/nonchris/domain-check";
+                platforms = platforms.unix;
+                maintainers = with maintainers; [ nonchris ];
+              };
+            };
+
+        };
+        defaultPackage = packages.domain-check;
+      });
+}


### PR DESCRIPTION
* create `flake.nix` for users using the nix package manager or running NixOS
* created a package for `domain-check`

This adds a few features:
* package can be easily installed on somebody's system
* package can be easily executed during development
* package can be easily tested by CI's

Commands that could be useful:
```sh
# execute the package through the nix flake
nix run

# build the package into ./result/bin/domain-check
nix build
```
